### PR TITLE
Adds tests (#24)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # Ignore generated files
 **/*.pyc
+config.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-config.py
+./config.py
 __pycache__
 orcidflask/__pycache__

--- a/orcidflask/__init__.py
+++ b/orcidflask/__init__.py
@@ -31,7 +31,8 @@ postgres_db = os.getenv('POSTGRES_DB')
 app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{postgres_user}:{postgres_pwd}@{postgres_db_host}:{postgres_port}/{postgres_db}'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db_key_file = os.getenv('DB_ENCRYPTION_FILE')
-app.config['db_encryption_key'] = load_encryption_key(db_key_file)
+if not os.getenv('TESTING'):
+    app.config['db_encryption_key'] = load_encryption_key(db_key_file)
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 

--- a/orcidflask/views.py
+++ b/orcidflask/views.py
@@ -52,6 +52,7 @@ def index():
         # Get the reason for auth failure if exists
         elif auth.get_settings().is_debug_active():
             error_reason = auth.get_last_error_reason()
+            app.logger.error(error_reason)
 
     # Handle logout
     elif 'sls' in request.args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,14 @@ cryptography==38.0.1
 Flask==2.3.3
 Flask-SQLAlchemy==2.5.1
 Flask-Migrate==4.0.7
+freezegun==1.5.1
 gunicorn==20.1.0
-psycopg2-binary==2.9.3
+lxml==5.3.0 # Need to pin version -- see below
+psycopg2-binary==2.9.8
 python3-saml==1.16.0
-requests==2.25.1
+pytest==8.3.5
+requests==2.30.0
+responses==0.25.7
 six==1.15.0
 SQLAlchemy==1.4.40
+xmlsec==1.3.14  # Need to pin version to avoid conflict with lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-cryptography==38.0.1
+cryptography==43.0.1
 Flask==2.3.3
 Flask-SQLAlchemy==2.5.1
 Flask-Migrate==4.0.7
-freezegun==1.5.1
-gunicorn==20.1.0
+gunicorn==23.0.0
 lxml==5.3.0 # Need to pin version -- see below
 psycopg2-binary==2.9.8
 python3-saml==1.16.0

--- a/tests.docker-compose.yml
+++ b/tests.docker-compose.yml
@@ -15,14 +15,14 @@ services:
     links:
       - db:db
     environment:
-      - ORCIDFLASK_SETTINGS=/opt/orcid_integration/config.py
+      - ORCIDFLASK_SETTINGS=/opt/orcid_integration/tests/config.py
       - POSTGRES_USER=testuser
       - POSTGRES_PASSWORD=testpass
       - POSTGRES_DB=testdb
       - POSTGRES_DB_HOST=db
       - POSTGRES_PORT=5432
       - TESTING=true
-    command: "pytest -s"
+    command: "pytest"
     volumes:
       - ./config.py:/opt/orcid_integration/config.py
       - ./tests:/opt/orcid_integration/tests 

--- a/tests.docker-compose.yml
+++ b/tests.docker-compose.yml
@@ -24,6 +24,5 @@ services:
       - TESTING=true
     command: "pytest"
     volumes:
-      - ./config.py:/opt/orcid_integration/config.py
       - ./tests:/opt/orcid_integration/tests 
     

--- a/tests.docker-compose.yml
+++ b/tests.docker-compose.yml
@@ -1,0 +1,29 @@
+version: "2"
+services:
+  db:
+    image: postgres:16.2
+    environment:
+      - POSTGRES_USER=testuser
+      - POSTGRES_PASSWORD=testpass
+      - POSTGRES_DB=testdb
+  flask-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    links:
+      - db:db
+    environment:
+      - ORCIDFLASK_SETTINGS=/opt/orcid_integration/config.py
+      - POSTGRES_USER=testuser
+      - POSTGRES_PASSWORD=testpass
+      - POSTGRES_DB=testdb
+      - POSTGRES_DB_HOST=db
+      - POSTGRES_PORT=5432
+      - TESTING=true
+    command: "pytest -s"
+    volumes:
+      - ./config.py:/opt/orcid_integration/config.py
+      - ./tests:/opt/orcid_integration/tests 
+    

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,9 @@
+SECRET_KEY = b'random string'
+CLIENT_ID = 'APP-1234567890'
+CLIENT_SECRET = 'xxxxxxxxxxxxxxxxxxxxxxxxxx'
+SERVER_NAME = 'localhost'
+SLO_REDIRECT = 'http://localhost/orcid'
+ORCID_SUCCESS_URL = 'http://localhost/orcid-connected'
+ORCID_FAILURE_URL = 'https://localhost/orcid-disconnected'
+# Set to true to prepopulate ORCID's registration for with values from the SAML IdP
+PREFILL_REGISTRATION = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+import pytest 
+import os
+from orcid_utils import create_encryption_key
+import json
+from orcidflask import app, db
+
+
+@pytest.fixture(scope='module')
+def saml_settings():
+    return {
+        'strict': True,
+        'debug': True,
+        'sp': {
+            'entityId': 'https://test.orcid.library.gwu.edu/metadata/',
+            'assertionConsumerService': {
+                'url': 'http://localhost/?acs',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
+            },
+            'singleLogoutService': {
+                'url': 'http://localhost/?sls',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            },
+            'NameIDFormat': 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
+            'x509cert': '',
+            'privateKey': ''
+        },
+        'idp': {
+            'entityId': 'http://idp.example.com',
+            'singleSignOnService': {
+                'url': 'http://idp.example.com/saml2',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            },
+            'singleLogoutService': {
+                'url': 'http://idp.example.com/saml2',
+                'responseUrl': 'http://idp.example.com/saml2',
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            },
+            'x509cert': 'MIICajCCAdOgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBSMQswCQYDVQQGEwJ1czETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMT25lbG9naW4gSW5jMRcwFQYDVQQDDA5zcC5leGFtcGxlLmNvbTAeFw0xNDA3MTcxNDEyNTZaFw0xNTA3MTcxNDEyNTZaMFIxCzAJBgNVBAYTAnVzMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQKDAxPbmVsb2dpbiBJbmMxFzAVBgNVBAMMDnNwLmV4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZx+ON4IUoIWxgukTb1tOiX3bMYzYQiwWPUNMp+Fq82xoNogso2bykZG0yiJm5o8zv/sd6pGouayMgkx/2FSOdc36T0jGbCHuRSbtia0PEzNIRtmViMrt3AeoWBidRXmZsxCNLwgIV6dn2WpuE5Az0bHgpZnQxTKFek0BMKU/d8wIDAQABo1AwTjAdBgNVHQ4EFgQUGHxYqZYyX7cTxKVODVgZwSTdCnwwHwYDVR0jBBgwFoAUGHxYqZYyX7cTxKVODVgZwSTdCnwwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQByFOl+hMFICbd3DJfnp2Rgd/dqttsZG/tyhILWvErbio/DEe98mXpowhTkC04ENprOyXi7ZbUqiicF89uAGyt1oqgTUCD1VsLahqIcmrzgumNyTwLGWo17WDAa1/usDhetWAMhgzF/Cnf5ek0nK00m0YZGyc4LzgD0CROMASTWNg=='
+        }
+    }
+
+@pytest.fixture(scope='module')
+def saml_settings_path(tmpdir_factory, saml_settings):
+    settings_dir = tmpdir_factory.mktemp('saml')
+    settings_file = settings_dir.join('settings.json')
+    with open(settings_file, 'w') as f:
+        json.dump(saml_settings, f)
+    return str(settings_dir)
+
+
+
+@pytest.fixture(scope='module')
+def test_app(saml_settings_path):
+    app.config.update({'db_encryption_key': create_encryption_key(),
+                        'SAML_PATH': saml_settings_path,
+    })
+    yield app
+
+
+@pytest.fixture(scope='module')
+def client(test_app):
+    return test_app.test_client()
+
+@pytest.fixture()
+def runner(test_app):
+    return test_app.test_cli_runner()
+
+@pytest.fixture(scope='module')
+def database(client):
+
+    db.drop_all()
+    db.create_all()
+
+    yield
+
+    db.session.remove()
+    db.drop_all()
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,2 @@
+def test_config(test_app, database):
+    print(test_app.config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,2 +1,0 @@
-def test_config(test_app, database):
-    print(test_app.config)

--- a/tests/test_orcid_oauth.py
+++ b/tests/test_orcid_oauth.py
@@ -1,0 +1,69 @@
+import pytest 
+from flask import session, url_for
+from urllib.parse import urlparse, parse_qs
+import responses
+from responses import matchers
+import requests
+from orcidflask.models import Token
+import datetime
+
+@pytest.fixture()
+def user_attributes():
+    return {'samlUserdata': {
+                            'emailaddress': ['test@example.com'],
+                             'firstname': ['Test'],
+                             'lastname': ['User']
+                            },
+            'samlNameId': 'testId'
+            }
+
+@pytest.fixture()
+def auth_code():
+    return 'test_code'
+
+@pytest.fixture()
+def redirect_url(test_app):
+    with test_app.app_context():
+        return url_for('orcid_redirect', _external=True, _scheme='https')
+
+def test_orcid_login(client, user_attributes, test_app):
+    with client.session_transaction() as session:
+        session['samlUserdata'] = user_attributes.get('samlUserdata')
+        session['samlNameId'] = user_attributes.get('samlNameId')
+    response = client.get('/orcid', query_string={'scopes': '/read-limited /activities/update', 'register': 'True'})
+    assert response.status_code == 302
+    redirect = urlparse(response.location)
+    query = parse_qs(redirect.query)
+    if test_app.config['PREFILL_REGISTRATION']:
+        assert redirect.path == urlparse(test_app.config['orcid_register_url']).path
+        assert query['family_names'] == user_attributes['samlUserdata']['lastname']
+        assert query['given_names'] == user_attributes['samlUserdata']['firstname']
+        assert query['email'] == user_attributes['samlUserdata']['emailaddress']
+    else:
+        assert redirect.path == urlparse(test_app.config['orcid_auth_url']).path
+    assert query['client_id'][0] == test_app.config['CLIENT_ID']
+
+@responses.activate   
+def test_orcid_redirect(client, test_app, auth_code, redirect_url, user_attributes, database):
+    orcid_resp_mock = responses.Response(
+        method='POST',
+        url=test_app.config['orcid_token_url'],
+        json={ 'access_token': 'test-access-token',
+              'refresh_token': 'test-refresh-token',
+              'expires_in': 631138518,
+              'scope': '/read-limited /activities/update',
+              'orcid': '0000-0000-0000-0000' },
+        match=[matchers.urlencoded_params_matcher({ 'client_id': test_app.config['CLIENT_ID'],
+                                                    'client_secret': test_app.config['CLIENT_SECRET'],
+                                                    'grant_type': 'authorization_code',
+                                                    'code': auth_code,
+                                                     'redirect_uri': redirect_url})
+            ],
+    )
+    responses.add(orcid_resp_mock)
+    orcid_resp = client.get('/orcid-redirect', query_string={'code': auth_code})
+    assert orcid_resp.status_code == 302
+    db_state = [record.to_dict() for record in Token.query.all()]
+    assert db_state[0]['userId'] == user_attributes.get('samlNameId')
+    assert db_state[0]['access_token'] == 'test-access-token'
+    assert db_state[0]['orcid'] == '0000-0000-0000-0000' 


### PR DESCRIPTION
Adds test coverage (pytest) for the non-SAML endpoints, including database functionality.

Testing with Docker containers uses a dedicated (non-persistent) database volume. 

This branch also addresses a couple of Dependabot alerts, with upgrades to the cryptography and gunicorn packages.

To run the tests, simply do `docker compose -f tests.docker-compose.yml up`. Confirm that all tests are passing.